### PR TITLE
Consistency with tags

### DIFF
--- a/ITAF CONFIG.txt
+++ b/ITAF CONFIG.txt
@@ -44,6 +44,7 @@ See wiki for details on parameters.
 			<bank-max-deg type="double">25</bank-max-deg> <!-- Maximum bank limit -->
 			<custom-fma type="bool">0</custom-fma> <!-- Call functions when modes change for a custom FMA to be implemented --> 
 			<disable-final type="bool">0</disable-final> <!-- Disable the Final Controllers for custom FCS integration -->
+			<engine-count type="int">2</engine-count> <!-- The number of engines your airplane has -->
 			<elevator-in-trim type="double">0.01</elevator-in-trim> <!-- Normalized elevator to stop trimming -->
 			<elevator-out-of-trim type="double">0.02</elevator-out-of-trim> <!-- Normalized elevator to start trimming -->
 			<fd-starts-on type="bool">1</fd-starts-on> <!-- Enable/Disable Flight Director being on by default -->

--- a/JSBsim Only/Systems/gear-agl-ft.xml
+++ b/JSBsim Only/Systems/gear-agl-ft.xml
@@ -12,10 +12,10 @@
 		<gain>1.0</gain>
 		<input>
 			<expression>
-				<dif>
+				<difference>
 					<property>/position/altitude-agl-ft</property>
 					<value>15</value> <!-- Change this value to adjust property -->
-				</dif>
+				</difference>
 			</expression>
 		</input>
 		<output>/position/gear-agl-ft</output>

--- a/Nasal/it-autoflight.nas
+++ b/Nasal/it-autoflight.nas
@@ -168,7 +168,7 @@ var Internal = {
 	takeoffHdg: props.globals.initNode("/it-autoflight/internal/takeoff-hdg", 0, "INT"),
 	takeoffHdgCalc: 0,
 	takeoffLvl: props.globals.initNode("/it-autoflight/internal/takeoff-lvl", 1, "BOOL"),
-	throttle: [props.globals.initNode("/it-autoflight/internal/throttle[0]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[1]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[2]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[3]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[4]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[5]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[6]", 0, "DOUBLE"), props.globals.initNode("/it-autoflight/internal/throttle[7]", 0, "DOUBLE")],
+	throttle: [],
 	vs: props.globals.initNode("/it-autoflight/internal/vert-speed-fpm", 0, "DOUBLE"),
 	vsTemp: 0,
 };
@@ -215,6 +215,7 @@ var Settings = {
 	bankMaxDeg: props.globals.getNode("/it-autoflight/settings/bank-max-deg", 1),
 	customFma: props.globals.getNode("/it-autoflight/settings/custom-fma", 1),
 	disableFinal: props.globals.getNode("/it-autoflight/settings/disable-final", 1),
+	engineCount: props.globals.getNode("/it-autoflight/settings/engine-count", 1),
 	fdStartsOn: props.globals.getNode("/it-autoflight/settings/fd-starts-on", 1),
 	groundModeSelect: props.globals.getNode("/it-autoflight/settings/ground-mode-select", 1),
 	hdgHldSeparate: props.globals.getNode("/it-autoflight/settings/hdg-hld-separate", 1),
@@ -296,6 +297,9 @@ var ITAF = {
 		Output.ap2.setBoolValue(0);
 		Output.ap3.setBoolValue(0);
 		Output.athr.setBoolValue(0);
+		for (var i = 0; i < Settings.engineCount.getValue(); i++) {
+			append(Internal.throttle, props.globals.initNode("/it-autoflight/internal/throttle[" ~ i ~ "]", 0, "DOUBLE"));
+		}
 		if (t != 1) {
 			Output.fd1.setBoolValue(Settings.fdStartsOn.getBoolValue());
 			Output.fd2.setBoolValue(Settings.fdStartsOn.getBoolValue());
@@ -664,14 +668,9 @@ var ITAF = {
 			}
 		} else {
 			if (!Settings.useControlsEngines.getBoolValue()) {
-				setprop("/controls/engines/engine[0]/throttle", Internal.throttle[0].getValue());
-				setprop("/controls/engines/engine[1]/throttle", Internal.throttle[1].getValue());
-				setprop("/controls/engines/engine[2]/throttle", Internal.throttle[2].getValue());
-				setprop("/controls/engines/engine[3]/throttle", Internal.throttle[3].getValue());
-				setprop("/controls/engines/engine[4]/throttle", Internal.throttle[4].getValue());
-				setprop("/controls/engines/engine[5]/throttle", Internal.throttle[5].getValue());
-				setprop("/controls/engines/engine[6]/throttle", Internal.throttle[6].getValue());
-				setprop("/controls/engines/engine[7]/throttle", Internal.throttle[7].getValue());
+				for (var i = 0; i < Settings.engineCount.getValue(); i++) {
+					setprop("/controls/engines/engine[" ~ i ~ "]/throttle", Internal.throttle[i].getValue());
+				}
 			}
 			Output.athr.setBoolValue(0);
 		}

--- a/Systems/it-autoflight.xml
+++ b/Systems/it-autoflight.xml
@@ -1893,10 +1893,10 @@
 			<u_min>
 				<expression>
 					<max>
-						<dif>
+						<difference>
 							<property>/orientation/pitch-deg</property>
 							<value>5</value>
-						</dif>
+						</difference>
 						<value>-15</value>
 					</max>
 				</expression>


### PR DESCRIPTION
There were the use of both ``</dif>`` and ``</difference>`` tags in the code; I have changed it so that all references are ``</dif>``. I've also edited the throttle code so that properties that do not exist are not called. This requires another parameter added to the settings - I have set the default to two engines so that anyone who attempts to copy it without first tuning the parameters will be more likely to have it work than not.